### PR TITLE
Added an assert for version 0.4.0-dev, plus .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.class
+*.log
+dist/*
+target/
+
+# Scala-IDE specific
+.idea/*
+api.iml
+

--- a/src/test/java/org/ipfs/api/Test.java
+++ b/src/test/java/org/ipfs/api/Test.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 
+import static org.junit.Assert.assertTrue;
+
 public class Test {
 
     IPFS ipfs = new IPFS(new MultiAddress("/ip4/127.0.0.1/tcp/5001"));
@@ -346,6 +348,7 @@ public class Test {
     public void toolsTest() {
         try {
             String version = ipfs.version();
+            assertTrue(version.equals("0.4.0-dev"));     // No longer works with any 0.3 version
             Map commands = ipfs.commands();
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
The assert is kind of fragile, since it won't work when 0.4.0 is released, but it is trivial to fix, and I think this is better than before, since it took me hours of useless debugging with 0.3.11.