### PR TITLE
Update README build & test instructions, dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,15 @@ Multihash filePointer = Multihash.fromBase58("QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ew
 byte[] fileContents = ipfs.cat(filePointer);
 ```
 
+## Dependencies
+* [Multiaddr](https://github.com/multiformats/java-multiaddr)
+* [Multihash](https://github.com/multiformats/java-multihash)
+
 ## Building
 ---------
-To build just run make. There are no dependencies, just include the resulting IPFS.jar in your project. 
+To build just run `ant dist`. The dependencies are included in the `./lib` directory, and automatically copied to the `./dist/lib` directory.
 
-To run tests use make tests.
+To run tests use `ant test`.
 
 ## Contribute
 


### PR DESCRIPTION
* Reference the Ant build & test methods
* Document the dependencies now that Multiaddr and Multihash have been split out