### PR TITLE
update maven deps: include java-cid and update multihash

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,12 @@
 		<dependency>
 			<groupId>com.github.multiformats</groupId>
 			<artifactId>java-multihash</artifactId>
-			<version>v1.0.0</version>
+			<version>v1.1.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.ipld</groupId>
+			<artifactId>java-cid</artifactId>
+			<version>v1.0.1</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Fix maven dependencies in prep for v1.1.0: include [ipld/java-cid](https://github.com/ipld/java-cid) and upgrade multihash.

Note: I couldn't verify the tests because my local node is still running IPFS 0.4.4, but the dependencies all resolve and it seems to be sane.