### PR TITLE
Allow users to publish with a generated key + Check minimum version fix

### DIFF
--- a/src/main/java/io/ipfs/api/IPFS.java
+++ b/src/main/java/io/ipfs/api/IPFS.java
@@ -58,7 +58,7 @@ public class IPFS {
                 throw new IllegalStateException("You need to use a more recent version of IPFS! >= " + MIN_VERSION);
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/io/ipfs/api/IPFS.java
+++ b/src/main/java/io/ipfs/api/IPFS.java
@@ -303,11 +303,16 @@ public class IPFS {
 
     public class Name {
         public Map publish(Multihash hash) throws IOException {
-            return publish(Optional.empty(), hash);
+            return publish(hash, Optional.empty());
         }
 
+        public Map publish(Multihash hash, Optional<String> key) throws IOException {
+            return retrieveMap("name/publish?arg=/ipfs/"+hash + (key.isPresent() ? "&key="+key : ""));
+        }
+
+        @Deprecated
         public Map publish(Optional<String> id, Multihash hash) throws IOException {
-            return retrieveMap("name/publish?arg=" + (id.isPresent() ? id+"&arg=" : "") + "/ipfs/"+hash);
+            return IPFS.this.retrieveMap("name/publish?arg=" + (id.isPresent()?id + "&arg=":"") + "/ipfs/" + hash);
         }
 
         public String resolve(Multihash hash) throws IOException {

--- a/src/main/java/io/ipfs/api/IPFS.java
+++ b/src/main/java/io/ipfs/api/IPFS.java
@@ -54,14 +54,11 @@ public class IPFS {
         // Check IPFS is sufficiently recent
         try {
             String ipfsVersion = version();
-            String[] parts = ipfsVersion.split("\\.");
-            String[] minParts = MIN_VERSION.split("\\.");
-            if (parts[0].compareTo(minParts[0]) < 0
-                    || parts[1].compareTo(minParts[1]) < 0
-                    || parts[2].compareTo(minParts[2]) < 0)
+            if (!versionIsValid(ipfsVersion)) {
                 throw new IllegalStateException("You need to use a more recent version of IPFS! >= " + MIN_VERSION);
+            }
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            e.printStackTrace();
         }
     }
 
@@ -492,6 +489,28 @@ public class IPFS {
 
         public Object log() throws IOException {
             return retrieveAndParse("update/log");
+        }
+    }
+
+    private boolean versionIsValid(String version) {
+        String[] parts = version.split("\\.");
+        String[] minParts = MIN_VERSION.split("\\.");
+        int[] intParts = Arrays.stream(parts).mapToInt(Integer::parseInt).toArray();
+        int[] intMinParts = Arrays.stream(minParts).mapToInt(Integer::parseInt).toArray();
+        return isNewerThan(intParts, intMinParts);
+    }
+
+    private boolean isNewerThan(int[] current, int[] min) {
+        if (min.length == 0) {
+            return true;
+        } else if (current.length == 0) {
+            return false;
+        } else if (current[0] < min[0]) {
+            return false;
+        } else {
+            int[] tailCurrent = Arrays.copyOfRange(current, 1, current.length);
+            int[] tailMin = Arrays.copyOfRange(min, 1, min.length);
+            return isNewerThan(tailCurrent, tailMin);
         }
     }
 

--- a/src/main/java/io/ipfs/api/IPFS.java
+++ b/src/main/java/io/ipfs/api/IPFS.java
@@ -312,7 +312,7 @@ public class IPFS {
 
         @Deprecated
         public Map publish(Optional<String> id, Multihash hash) throws IOException {
-            return IPFS.this.retrieveMap("name/publish?arg=" + (id.isPresent()?id + "&arg=":"") + "/ipfs/" + hash);
+            return retrieveMap("name/publish?arg=" + (id.isPresent()?id + "&arg=":"") + "/ipfs/" + hash);
         }
 
         public String resolve(Multihash hash) throws IOException {


### PR DESCRIPTION
In IPFS class, I added a method "publish" in the inner class Name to allow users to publish with a choosen key.
Furthermore, I marked the method "publish(Optional<String> id, Multihash hash)" as Deprecated because the path is malformed : "name/publish?arg=id&arg=/ipfs/hash" (there are 2 parameters args) and does not comply with the HTTP API.

Since the version 0.4.10, the current algorithm doesn't work anymore because it compares two String objects so "3" > "10". I implemented a new one which compare two integers, recursively.