### PR TITLE
Correct API for ipfs pubsub peers <topic>

### DIFF
--- a/src/main/java/io/ipfs/api/IPFS.java
+++ b/src/main/java/io/ipfs/api/IPFS.java
@@ -232,7 +232,7 @@ public class IPFS {
         }
 
         public Object peers(String topic) throws IOException {
-            return retrieveAndParse("pubsub/peers?topic="+topic);
+            return retrieveAndParse("pubsub/peers?arg="+topic);
         }
 
         /**


### PR DESCRIPTION
The correct REST URL is using `arg` as argument and not `topic`.

See https://ipfs.io/docs/api/.