### PR TITLE
Run Java-Tests in Travis-Ci-Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ before_script:
   - export PATH=$PATH:$PWD/go-ipfs/
   - ipfs init
   - ipfs daemon --enable-pubsub-experiment &
+script:
+  - mvn clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -60,16 +60,29 @@
 			<groupId>com.github.multiformats</groupId>
 			<artifactId>java-multiaddr</artifactId>
 			<version>v1.1.1</version>
+			<scope>system</scope>
+			<systemPath>${project.basedir}/lib/multiaddr.jar</systemPath>
 		</dependency>
 		<dependency>
 			<groupId>com.github.multiformats</groupId>
 			<artifactId>java-multihash</artifactId>
+			<version>v1.1.1</version>
+			<scope>system</scope>
+			<systemPath>${project.basedir}/lib/multihash.jar</systemPath>
+		</dependency>
+		<dependency>
+			<groupId>com.github.multiformats</groupId>
+			<artifactId>java-multibase</artifactId>
 			<version>v1.1.0</version>
+			<scope>system</scope>
+			<systemPath>${project.basedir}/lib/multibase.jar</systemPath>
 		</dependency>
 		<dependency>
 			<groupId>com.github.ipld</groupId>
 			<artifactId>java-cid</artifactId>
 			<version>v1.1.0</version>
+			<scope>system</scope>
+			<systemPath>${project.basedir}/lib/cid.jar</systemPath>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
For running the Unit-Tests on Travis-Ci it is necessary to
- link the dependencies in the pom.xml (or push them to maven central)
- run the tests with mvn clean verify
- activate travis-ci