### PR TITLE
Enable tests for versions

### DIFF
--- a/src/test/java/io/ipfs/api/VersionsTest.java
+++ b/src/test/java/io/ipfs/api/VersionsTest.java
@@ -5,7 +5,7 @@ import org.junit.*;
 import java.util.*;
 import java.util.stream.*;
 
-public class Versions {
+public class VersionsTest {
 
     @Test
     public void sorting(){


### PR DESCRIPTION
Rename Versions to VersionsTest to make it run during Maven's test
phase:

    Running io.ipfs.api.VersionsTest
    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.108 sec - in io.ipfs.api.VersionsTest