### PR TITLE
Use java-multiaddress 1.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <version.junit>4.12</version.junit>
         <version.hamcrest>1.3</version.hamcrest>
-        <version.multiaddr>v1.3.0</version.multiaddr>
+        <version.multiaddr>v1.3.1</version.multiaddr>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
Use java-multiaddress 1.3.1 so we can start using `dnsaddr` multiaddress